### PR TITLE
Use trailing slash permalinks, not directories to create pretty permalinks

### DIFF
--- a/donations.md
+++ b/donations.md
@@ -1,12 +1,13 @@
 ---
 layout: page
 title: How to Donate
+permalink: /donations/
 ---
 
 # How to Donate
 
-Gifts to the Presidential Innovation Fellows Foundation are tax-deductible. 
-The PIFF is a Washington, DC, corporation recognized as a 501c3 corporation 
+Gifts to the Presidential Innovation Fellows Foundation are tax-deductible.
+The PIFF is a Washington, DC, corporation recognized as a 501c3 corporation
 by the IRS. Our EIN is: 47-1770767.
 
 Donate online:

--- a/donors.md
+++ b/donors.md
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: 2014 Sponsors
+permalink: /donors/
 ---
 
 # 2014 Sponsors


### PR DESCRIPTION
This pull request updates the `/donors` and `/donations` paths to leverage Jekyll's permalink generation functionality to create `donors/index.html` and `/donations/index.html` (maintaining the pretty permalinks) without the need to create sub directories for each. 

They can then each live at `/donors.md` and `/donations.md` and will be generated into the proper place on build.