### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,24 @@
-Presidential Innovation Fellows Foundation website
-===================
+# Presidential Innovation Fellows Foundation website
 
-### Requirements
+## How it works
 
-- Jekyll
-- GitHub Pages
-- Zurb Foundation 5
-- SASS (SCSS)
+The website is a static site built using [Jekyll](http://jekyllrb.com) and served using [GitHub Pages](https://pages.github.com). It is automatically built and published each time a change hits the `master` branch, or you can build the site locally by following the instructions below.
 
-### build it
+## Running locally
 
-- fork this repo
-- clone your version of it
+1. `git clone https://github.com/presidential-innovation-foundation/presidential-innovation-foundation.github.io`
+2. `cd presidential-innovation-foundation.github.io`
+3. `bundle install`
+4. `bundle exec jekyll serve`
+5. Open [`localhost:4000`](http://localhost:4000) in your browser
 
-```
-cd presidential-innovation-foundation.github.io
-bundle install
-```
+## Contributing
 
+1. Fork the repository
+2. Create a new, descriptively named branch
+3. Make your change
+4. Submit [a pull request](https://guides.github.com/introduction/flow/)
 
+## Contributors
 
-### Contributors
-
-- Sarah Allen
-- Danny Chapman
-- Jason Shen
-- Robert Read
-- Sokwoo Rhee
-- Henry Wei
-
+See [the list of contributors](https://github.com/presidential-innovation-foundation/presidential-innovation-foundation.github.io/graphs/contributors).


### PR DESCRIPTION
This pull request updates the readme in a few ways:

1. Explain how the site works in terms of what a contributor might need to do, not what's under the hood (assuming we use Jekyll's native Sass support via https://github.com/presidential-innovation-foundation/presidential-innovation-foundation.github.io/pull/13, the other factors are then baked in)

2. Step-by-step local build instructions (including how to preview the site locally)

3. Direction on how to contribute (fork and pull request)

4. Link out to the contributor page, rather than maintaining a human-curated list (unless there's more history behind having this in the readme that I'm missing?)