### PR TITLE
Add sitemap

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -31,3 +31,6 @@ highlighter: null
 markdown: kramdown
 timezone: America/New_York
 encoding: UTF-8
+
+gems:
+  - jekyll-sitemap


### PR DESCRIPTION
A follow up to the SEO efforts in https://github.com/presidential-innovation-foundation/presidential-innovation-foundation.github.io/pull/19, and dependent on https://github.com/presidential-innovation-foundation/presidential-innovation-foundation.github.io/pull/11, this adds an auto-generated, sitemaps.org compliant sitemap at `/sitemap.xml` via Jekyll magic.