### PR TITLE
Use content, not page.content

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -4,7 +4,7 @@
 <div class="row">
 <div class="small-10 small-centered columns">
 
-{{ page.content | markdownify }}
+{{ content }}
 
 </div>
 </div>


### PR DESCRIPTION
Per [the docs](http://jekyllrb.com/docs/variables/#global-variables), `{{ content }}` is the proper way to yield a page's content in a template, not `{{ page.content | markdownify }}`.