### PR TITLE
Create page for board of directors

### DIFF
--- a/_data/board.yml
+++ b/_data/board.yml
@@ -1,0 +1,19 @@
+- title: President
+  name: Sarah Allen
+  github: ultrasaurus
+
+- title: Vice President
+  name: James Sanders
+  github: jamestsanders
+
+- title: Secretary
+  name: Ben Balter
+  github: benbalter
+
+- title: Treasurer
+  name: Rob Read
+  github: robertlread
+
+- title: Member-at-Large
+  name: Ian Kalin
+  github: ianjkalin

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -4,6 +4,8 @@
 <div class="row">
 <div class="small-10 small-centered columns">
 
+<h2>{{ page.title }}</h2>
+
 {{ content }}
 
 </div>

--- a/_sass/_pif.scss
+++ b/_sass/_pif.scss
@@ -358,3 +358,10 @@ footer {
   }
   ol li ol li ol li { counter-increment: section; }
 }
+
+/*** Board ***/
+.board .members { margin-top: 25px; }
+.board .members img { width: 100px; float: left; }
+.board .member { margin-bottom: 25px; }
+.board .member .about { float: left; margin-left: 10px; font-size: 1.2em; }
+.board .member .about small { display: block; line-height: 1em; }

--- a/board.md
+++ b/board.md
@@ -1,0 +1,18 @@
+---
+layout: page
+title: Board of Directors
+permalink: /board/
+id: board
+---
+
+<ul class="members small-block-grid-1 medium-block-grid-2 large-block-grid-3">
+{% for member in site.data.board %}
+<li class="member">
+  <img src="https://github.com/{{ member.github }}.png">
+  <div class="about">
+    {{ member.name }}<br />
+    <small>{{ member.title }}</small>
+  </div>
+</li>
+{% endfor %}
+</ul>

--- a/board.md
+++ b/board.md
@@ -8,7 +8,7 @@ id: board
 <ul class="members small-block-grid-1 medium-block-grid-2 large-block-grid-3">
 {% for member in site.data.board %}
 <li class="member">
-  <img src="https://github.com/{{ member.github }}.png">
+  <img src="https://github.com/{{ member.github }}.png" alt="{{ member.name }}">
   <div class="about">
     {{ member.name }}<br />
     <small>{{ member.title }}</small>

--- a/bylaws.md
+++ b/bylaws.md
@@ -6,8 +6,6 @@ redirect_from: "/bylaws/PIFFbylaws.pdf"
 id: bylaws
 ---
 
-# Bylaws of the Presidential Innovation Fellows Foundation
-
 1. Article 1 — Name
 
     1. **Name.** The name of the corporation shall be Presidential Innovation Fellows Foundation (the "Corporation").

--- a/donations.md
+++ b/donations.md
@@ -4,8 +4,6 @@ title: How to Donate
 permalink: /donations/
 ---
 
-# How to Donate
-
 Gifts to the Presidential Innovation Fellows Foundation are tax-deductible.
 The PIFF is a Washington, DC, corporation recognized as a 501c3 corporation
 by the IRS. Our EIN is: 47-1770767.


### PR DESCRIPTION
With some help from one mr. @dannychapman this creates a page for the board of directors:

![screen shot 2015-03-05 at 2 57 02 pm](https://cloud.githubusercontent.com/assets/282759/6513571/da311fd2-c349-11e4-9968-3c967095dd12.png)

It will automatically pull everyone's gravatar based on their GitHub username.

/cc @presidential-innovation-foundation/board 

Fixes #27.