### PR TITLE
Add contact details

### DIFF
--- a/board.md
+++ b/board.md
@@ -16,3 +16,5 @@ id: board
 </li>
 {% endfor %}
 </ul>
+
+Looking to get in touch? We'd love to hear from you. Email us at <hello@presidentialinnovation.org>.

--- a/index.html
+++ b/index.html
@@ -125,6 +125,10 @@ title: Presidential Innovation Fellows Foundation
 
 <a href="./bylaws" class="button">Our bylaws</a>
 
+<a href="./board" class="button">Board</a>
+
+<p>Looking to get in touch? We'd love to hear from you. Email us at <a href="mailto:hello@presidentialinnovation.org">hello@presidentialinnovation.org</a>.</p>
+
     </div>
   </div>
 </div>


### PR DESCRIPTION
This add the `hello@` email to the footers of the main and board pages. It also adds a link to the board page from the main page, which I noticed was missing.

![screen shot 2015-05-22 at 2 23 22 pm](https://cloud.githubusercontent.com/assets/282759/7777117/3aef72fc-008e-11e5-92bf-007d7c1c865d.png)

![screen shot 2015-05-22 at 2 23 17 pm](https://cloud.githubusercontent.com/assets/282759/7777116/39e54328-008e-11e5-9b18-77c039ff5727.png)

Suggestions for different copy welcome. :smile:

Fixes https://github.com/presidential-innovation-foundation/presidential-innovation-foundation.github.io/issues/36

/cc @RobertLRead 