### PR TITLE
Reduce contributor friction by adding language-agnostic interfaces

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-script: "bundle exec rake test"
+script: "script/cibuild"
 
 language: ruby
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ The website is a static site built using [Jekyll](http://jekyllrb.com) and serve
 
 1. `git clone https://github.com/presidential-innovation-foundation/presidential-innovation-foundation.github.io`
 2. `cd presidential-innovation-foundation.github.io`
-3. `bundle install`
-4. `bundle exec jekyll serve`
+3. `script/bootstrap`
+4. `script/server`
 5. Open [`localhost:4000`](http://localhost:4000) in your browser
 
 ## Contributing
@@ -18,6 +18,10 @@ The website is a static site built using [Jekyll](http://jekyllrb.com) and serve
 2. Create a new, descriptively named branch
 3. Make your change
 4. Submit [a pull request](https://guides.github.com/introduction/flow/)
+
+## Testing
+
+`script/cibuild`
 
 ## Contributors
 

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+set -ex
+
+bundle install

--- a/script/cibuild
+++ b/script/cibuild
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+set -ex
+
+bundle exec rake test

--- a/script/server
+++ b/script/server
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+set -ex
+
+bundle exec jekyll serve --watch


### PR DESCRIPTION
See https://byparker.com/blog/2015/language-agnostic-interfaces-for-software-development/ and http://githubengineering.com/scripts-to-rule-them-all/ for some additional context, but in short, add `script/bootstrap`, `script/server` and `script/cibuild` scripts to make it easier for folks not familiar with Jekyll/Ruby to contribute.