### PR TITLE
changing information architecture

### DIFF
--- a/contact.md
+++ b/contact.md
@@ -1,0 +1,21 @@
+---
+layout: page
+title: Contact
+permalink: /contact/
+---
+
+## Twitter
+
+**@InnovFellows**
+
+All board members:
+
+**<board@presidentialinnovation.org>**
+
+For inquiries about donations or to request financial assistance for a project:
+
+**<pifftreas@gmail.com>**
+
+
+
+<!-- hhmts start -->Last modified: Tue Nov 11 12:48:40 EST 2014 <!-- hhmts end -->

--- a/formembers.md
+++ b/formembers.md
@@ -1,7 +1,7 @@
 ---
 layout: page
-title: Alumni Groups And Lists
-permalink: /groupsandlists/
+title: Alumni Groups And Lists (For Members)
+permalink: /formembers/
 ---
 
 ## Twitter
@@ -39,10 +39,6 @@ All board members:
 For inquiries about donations or to request financial assistance for a project:
 
 **<pifftreas@gmail.com>**
-
-
-
-
 
 
 <!-- hhmts start -->Last modified: Tue Nov 11 12:48:40 EST 2014 <!-- hhmts end -->


### PR DESCRIPTION
@benbalter Ben, would you be so kind as to check and merge this pull request?

It is my attempt to do what @ultrasaurus and you suggested.  I created a "contact" page (you can merge that with the board page if you want.  I created a separate "formembers" page. The "contact" page is a subset of the "formembers" page.

I assume we will link to "contact" on the home page, but not "formembers".  I have left the GSA emails in place on the formembers page.  We can of course change that --- it wasn't clear to me what the consensus was in the meeting today.